### PR TITLE
Add k6 load testing script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# API base URL for GET and POST requests
+BASE_URL=https://api.example.com/resource
+# Authentication token (if required)
+TOKEN=your_access_token

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # timesheet-admin
+
+This repository provides a basic setup to run load tests using [k6](https://k6.io/).
+
+## Setup
+
+1. Install k6 (if not already installed):
+   ```bash
+   sudo apt-get update && sudo apt-get install -y k6
+   ```
+   or follow the instructions for your operating system in the [k6 documentation](https://k6.io/docs/getting-started/installation/).
+
+2. Create a `.env` file based on `.env.example` and set the target API URL and access token.
+
+## Running the load test
+
+Execute the following command:
+
+```bash
+k6 run --env-file=.env k6/load-test.js
+```
+
+The script issues scalable GET and POST requests to the configured API.

--- a/k6/load-test.js
+++ b/k6/load-test.js
@@ -1,0 +1,35 @@
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+const baseUrl = __ENV.BASE_URL
+const token = __ENV.TOKEN
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 5 },
+    { duration: '1m', target: 20 },
+    { duration: '30s', target: 0 }
+  ]
+}
+
+export default function () {
+  const params = {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    }
+  }
+
+  const getResponse = http.get(baseUrl, params)
+  check(getResponse, {
+    'get status is 200': (r) => r.status === 200
+  })
+
+  const payload = JSON.stringify({ example: 'data' })
+  const postResponse = http.post(baseUrl, payload, params)
+  check(postResponse, {
+    'post status is 200': (r) => r.status === 200
+  })
+
+  sleep(1)
+}


### PR DESCRIPTION
## Summary
- add k6 load-test script with GET and POST requests
- document usage and installation in README
- provide `.env.example` for API configuration

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx eslint -c .eslintrc.json k6/load-test.js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687c048dc20c8330b03616b5a06096b8